### PR TITLE
Further controller support (dpad)

### DIFF
--- a/data/scripts/button_inputs.lua
+++ b/data/scripts/button_inputs.lua
@@ -118,6 +118,60 @@ function menu:initialize(game)
 
     return handled
   end
+
+  function game:on_joypad_hat_moved(hat, direction)
+    handled = false
+    if hat == 0 then
+      if direction == 0 then
+        game:simulate_command_released("up")
+        game:simulate_command_released("down")
+        game:simulate_command_pressed("right")
+        handled = true
+      elseif direction == 1 then
+        game:simulate_command_released("down")
+        game:simulate_command_pressed("right")
+        game:simulate_command_pressed("up")
+        handled = true
+      elseif direction == 2 then
+        game:simulate_command_released("left")
+        game:simulate_command_released("right")
+        game:simulate_command_pressed("up")
+        handled = true
+      elseif direction == 3 then
+        game:simulate_command_released("right")
+        game:simulate_command_pressed("up")
+        game:simulate_command_pressed("left")
+        handled = true
+      elseif direction == 4 then
+        game:simulate_command_released("up")
+        game:simulate_command_released("down")
+        game:simulate_command_pressed("left")
+        handled = true
+      elseif direction == 5 then
+        game:simulate_command_released("up")
+        game:simulate_command_pressed("left")
+        game:simulate_command_pressed("down")
+        handled = true
+      elseif direction == 6 then
+        game:simulate_command_released("left")
+        game:simulate_command_released("right")
+        game:simulate_command_pressed("down")
+        handled = true
+      elseif direction == 7 then
+        game:simulate_command_released("left")
+        game:simulate_command_pressed("down")
+        game:simulate_command_pressed("right")
+        handled = true
+      elseif direction == -1 then
+        game:simulate_command_released("right")
+        game:simulate_command_released("up")
+        game:simulate_command_released("left")
+        game:simulate_command_released("down")
+        handled = true
+      end
+    end
+    return handled
+  end
   
 end
 

--- a/data/scripts/menus/dialog_box.lua
+++ b/data/scripts/menus/dialog_box.lua
@@ -527,6 +527,14 @@ local function initialize_dialog_box_features(game)
     return true
   end
 
+  function dialog_box:on_joypad_hat_moved(hat, command)
+    if command == 6 then
+      dialog_box:on_command_pressed("down")
+    elseif command == 2 then
+      dialog_box:on_command_pressed("up")
+    end
+  end
+
   -- Draws the dialog box.
   function dialog_box:on_draw(dst_surface)
 


### PR DESCRIPTION
I added some further controller support that bugged be a little when trying this awesomely charming game out.
The dialogs should now be usable with a dpad just like the main menu.
And then the hero should now also move using the dpad as well which I thought is super fitting for a 16-bit style Bloodborne-inspired game.