### PR TITLE
hotfixed menu music not starting

### DIFF
--- a/data/scripts/menus/solarus_logo.lua
+++ b/data/scripts/menus/solarus_logo.lua
@@ -71,8 +71,10 @@ end
 
 -- Starting the menu.
 function solarus_logo_menu:on_started()
-  --Start music
-  sol.audio.play_music"hunters_dream"
+  sol.timer.start(1, function()
+    --Start music
+    sol.audio.play_music("hunters_dream")
+  end)
   -- Initialize or reinitialize the animation.
   animation_step = 0
   timer = nil

--- a/data/scripts/menus/title.lua
+++ b/data/scripts/menus/title.lua
@@ -14,6 +14,8 @@ local options_x = 185
 local options_y = 200
 
 function menu:on_started()
+  sol.audio.play_music("hunters_dream") -- make sure the music runs, in case it didn't start on the screen before
+
 	menu.surface = sol.surface.create()
   menu.bg = sol.surface.create("menus/title_screen_background.png")
   menu.cursor = sol.surface.create("menus/cursor.png")


### PR DESCRIPTION
problem occurred after quitting a running game for restart

I'm really not to fond of these kinds of fixes, but there seems to be a race condition when the engine reset (sol.main.reset) is done and the game is restarting. When doing so the menu music is starting, but not audible.
I investigated quite a bit, but I guess my understanding of how the engine works is just not enough to get why this is happening. Hence I'm opening this PR as a place to discuss this.